### PR TITLE
Use subshell for linking CSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn watch # HTTP server listening on 7000
 # generate HTML from another terminal after watch server started
 yarn page
 # add soft link for the CSS file
-cd target && ln -s ../entry/
+(cd target && ln -s ../entry/)
 ```
 
 Build:


### PR DESCRIPTION
Added parens around the `cd target …` soft linking command. So as
not to have the side effect of changin the current directory.