### PR TITLE
Fix overflow bugs in safari

### DIFF
--- a/entry/main.css
+++ b/entry/main.css
@@ -93,4 +93,5 @@ body * {
 
 .logo-circle {
     overflow: hidden;
+    transform: translateZ(0);
 }


### PR DESCRIPTION
I noticed a very common overflow bug when hovering website logo in safari.
The fix may be considered a hack, but it works!

![ezgif-2-584425e710b3](https://user-images.githubusercontent.com/17655/54401296-276f5a00-46d8-11e9-8334-79d36afd444c.gif)
